### PR TITLE
Update instructions to follow the thread

### DIFF
--- a/src/slack/views/postQuestionAnonymouslySubmitted.ts
+++ b/src/slack/views/postQuestionAnonymouslySubmitted.ts
@@ -30,7 +30,7 @@ If you can answer this question, post a response in a thread!`;
       text: `:warning: You won't be notified automatically when someone replies to this question. To get notifications from replies, follow the thread:
 - :one: Hover over the message (mobile app: tap the message)
 - :two: Click message options (three dots)
-- :three: Select \`Follow thread\`
+- :three: Select \`Get notified about new replies\`
 
 If you want to reply to a response, use the  \`Reply Anonymously\` message shortcut (click in message options and search under  \`More message shortcuts\`).`,
     });


### PR DESCRIPTION
'Follow Thread' is no longer a thing. It says "Get notified about new replies" in the message options.

## Pre-Requisites
- [ ] Yes, I updated [Authors.md](../Authors.md) **OR** this is not my first contribution
- [X] Yes, I included and/or modified tests to cover relevent code **OR** my change is non-technical
- [X] Yes, I wrote this code entirely myself **OR** I properly attributed these changes in [Third Party Notices](../THIRD-PARTY-NOTICES.txt)

## Description of Changes
<!-- Enter a description of what this PR adds/changes -->

changed the automated response when someone posts an anonymous question. "Follow thread" is no longer existing. It is updated as "Get notified about new replies"

## Related Issues
<!-- Include a list and brief description of any tracked issues -->
<!-- e.g., "Fixes #123 - A bug that crashes the app" -->
<!-- NOTE: Each bugfix needs to use the "Fixes" or "Closes" and needs to be on its own line -->
